### PR TITLE
Use same version of lodash as babel, to reduce duplication in modules tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "chalk": "^1.1.1",
     "express": "^4.13.3",
     "json-loader": "^0.5.4",
-    "lodash": "^4.0.0",
+    "lodash": "^3.10.0",
     "pretty-ms": "^2.1.0",
     "progress": "^1.1.8",
     "rimraf": "^2.5.0",


### PR DESCRIPTION
Fixes #67 