### PR TITLE
Add NODE_ENV=production on minified build

### DIFF
--- a/src/createCompiler.js
+++ b/src/createCompiler.js
@@ -111,8 +111,14 @@ module.exports = function createCompiler(opts) {
   if (frontEnd)
     config.plugins.push(new BundleUpdateHookPlugin());
 
-  if (opts.minify)
+  if (opts.minify) {
     config.plugins.push(new webpack.optimize.UglifyJsPlugin());
+    config.plugins.push(new webpack.DefinePlugin({
+      'process.env': {
+        NODE_ENV: JSON.stringify('production')
+      }
+    }));
+  }
 
   // Are we creating a config for backend?
   if (backEnd) {


### PR DESCRIPTION
A lot of projects uses 

```
if (process.env.NODE_ENV !== 'production') {
}
```

Like React and others. 
Performance and code size depends on this variable. 
It is better with minification settings to also set `NODE_ENV = production`

