### PR TITLE
babelrc babel option

### DIFF
--- a/src/createCompiler.js
+++ b/src/createCompiler.js
@@ -214,7 +214,8 @@ module.exports = function createCompiler(opts) {
       exclude: /(node_modules|bower_components)/,
       loader: BABEL_LOADER,
       query: {
-        presets: presets
+        presets: presets,
+        babelrc: opts.babel
       }
     };
 


### PR DESCRIPTION
Based on this [line](https://github.com/Yomguithereal/kotatsu/blob/master/cli.js#L225)

```
.example('kotatsu serve --babel entry.js', 'Enable Babel to use .babelrc files.')
```

I thought that you disable usage of `babelrc` files if `--babel` is not set,
but without current change babel-loader is reading `.babelrc` files in folders
