### PR TITLE
Always respond with index

### DIFF
--- a/src/createServer.js
+++ b/src/createServer.js
@@ -75,15 +75,6 @@ module.exports = function createServer(compiler, opts) {
     });
   }
 
-  // Sending the index
-  app.get('/', function(req, res) {
-
-    if (opts.index)
-      return res.sendFile(opts.index);
-
-    return res.send(index);
-  });
-
   // Proxy
   if (opts.proxy) {
     var proxies = _.chunk(opts.proxy, 2);
@@ -104,6 +95,15 @@ module.exports = function createServer(compiler, opts) {
       }));
     });
   }
+
+  // Sending the index
+  app.get('*', function(req, res) {
+
+    if (opts.index)
+      return res.sendFile(opts.index);
+
+    return res.send(index);
+  });
 
   // res.sendFile
   return app;


### PR DESCRIPTION
The index file should always be responded with. Very often you build apps that uses PushState and the index is always responded, no matter what url.

To make this work correctly I also moved the proxy before the `get('*')` to ensure that any proxied requests goes to the server and is not caught by this universal thingy :-)

This has been tested on webpackbin btw