### PR TITLE
Add 'mountNode' param to render for react example

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ import App from './App.jsx';
 
 const mountNode = document.getElementById('app');
 
-render(<App />);
+render(<App />, mountNode);
 ```
 
 **4. Using kotatsu**


### PR DESCRIPTION
if not 'mountNode' not provided you'll get : 
Uncaught Invariant Violation: _registerComponent(...): Target container is not a DOM element.