### PR TITLE
FIX Readme.md: app not being exported

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ var app = express();
 app.get('/', function(req, res) {
   return res.send('Hello World!');
 });
+
+module.exports = app;
 ```
 
 **3. Creating our startup script**


### PR DESCRIPTION
The example won't work without `app` being exported.