### PR TITLE
Added option for webpack-dashboard.

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -216,6 +216,11 @@ var argv = yargs
     type: 'boolean',
     default: false
   })
+  .option('dashboard', {
+    describe: 'Display webpack info via dashboard.',
+    type: 'boolean',
+    default: false
+  })
 
   // Examples
   .example('kotatsu start script.js', 'Launching the given script with HMR.')
@@ -268,7 +273,8 @@ var opts = {
   progress: argv.progress,
   proxy: argv.proxy,
   quiet: argv.quiet,
-  sourceMaps: argv.sourceMaps
+  sourceMaps: argv.sourceMaps,
+  dashboard: argv.dashboard
 };
 
 // Cleaning null values

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "source-map-support": "^0.4.0",
     "webpack": "^1.12.13",
     "webpack-bundle-update-hook-plugin": "^1.0.2",
+    "webpack-dashboard": "^0.1.8",
     "webpack-dev-middleware": "^1.5.1",
     "webpack-hot-middleware": "^2.7.1",
     "winston": "^2.1.1",

--- a/src/createServer.js
+++ b/src/createServer.js
@@ -10,7 +10,8 @@ var express = require('express'),
     cors = require('cors'),
     dev = require('webpack-dev-middleware'),
     hot = require('webpack-hot-middleware'),
-    _ = require('lodash');
+    _ = require('lodash'),
+    DashboardPlugin = require('webpack-dashboard/plugin');
 
 /**
  * Constants.
@@ -70,6 +71,9 @@ module.exports = function createServer(compiler, opts) {
     DEV_MIDDLEWARE_OPTS,
     _.get(opts, ['config', 'devServer'], {})
   );
+
+  if (opts.dashboard)
+    compiler.apply(new DashboardPlugin());
 
   // Middlewares
   if (opts.cors)


### PR DESCRIPTION
This is just an idea right now but i'd like to support the webpack-dashboard plugin. Right now this just adds the proper plugin but to run kotatsu with dashboard, the command would need to look something like this:

```
webpack-dashboard -- kotatsu serve \
  --dashboard
```

I would prefer to call the webpack-dashboard from the serve command but my experience with node is limited and I can't figure out how to hook these things up.